### PR TITLE
Do not throw exception on --TEST-- section

### DIFF
--- a/src/PsalmTest.php
+++ b/src/PsalmTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\Constraint\StringMatchesFormatDescription;
  */
 final class PsalmTest
 {
+    private const TEST = 'TEST';
     private const FILE = 'FILE';
     private const ARGS = 'ARGS';
     private const EXPECT = 'EXPECT';


### PR DESCRIPTION
`--TEST--` is required, let's do not throw an exception is it's available in the .phpt file.

It's not full support of this section, but better than asking developers to write not valid .phpt files.


## Materials
From https://www.jetbrains.com/help/phpstorm/phpt-support.html

> At the bare minimum, a PHPT test must contain the TEST, FILE, and EXPECT sections.

