### PR TITLE
Support PHPUnit 10-12

### DIFF
--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+
+// command: composer check-deps
+// see https://github.com/shipmonk-rnd/composer-dependency-analyser
+
+$config = new Configuration();
+
+return $config
+    // Adjusting scanned paths
+    ->addPathToScan(__DIR__ . '/src', isDev: false);

--- a/composer-require-checker.json
+++ b/composer-require-checker.json
@@ -1,5 +1,0 @@
-{
-    "symbol-whitelist": [
-        "Composer\\InstalledVersions"
-    ]
-}

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,16 @@
     ],
     "require": {
         "php": "^8.1",
-        "phpunit/phpunit": "^9 || ^10"
+        "phpunit/phpunit": "^10 || ^11 || ^12"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.41.1",
         "friendsofphp/php-cs-fixer": "^3.48.0",
-        "icanhazstring/composer-unused": "^0.8.11",
-        "maglnet/composer-require-checker": "^4.7.1",
         "phpyh/coding-standard": "^2.6.0",
-        "psalm/plugin-phpunit": "^0.18.4",
+        "psalm/plugin-phpunit": "^0.19.0",
         "rector/rector": "^0.19.2",
-        "vimeo/psalm": "^5.20.0"
+        "shipmonk/composer-dependency-analyser": "^1.5",
+        "vimeo/psalm": "^5.20.0 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -43,8 +42,8 @@
         "sort-packages": true
     },
     "scripts": {
-        "check-require": "composer-require-checker check --config-file=composer-require-checker.json",
-        "check-unused": "composer-unused",
+        "check-deps": "@check-dependencies",
+        "check-dependencies": "vendor/bin/composer-dependency-analyser",
         "fixcs": "php-cs-fixer fix --diff --verbose",
         "pre-command-run": "mkdir -p var",
         "psalm": "psalm --show-info=true --no-diff",

--- a/rector.php
+++ b/rector.php
@@ -14,6 +14,6 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
     $rectorConfig->sets([
         LevelSetList::UP_TO_PHP_81,
-        PHPUnitSetList::PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_100,
     ]);
 };


### PR DESCRIPTION
Support PHPUnit 10-12

Also use shipmonk/composer-dependency-analyser to check composer dependencies (both unused and shadow) because the composer-unused package uses `nikic/php-parser` v4 that prevents installing Psalm 6, see https://github.com/composer-unused/composer-unused/blob/0.8.11/composer.json